### PR TITLE
Support for options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,13 @@ module.exports = function(grunt) {
           'tmp/globals.js': ['test/fixtures/input.js'],
           'tmp/globals-bar.js': ['test/fixtures/bar.js']
         }
-      }
+      },
+      moduleName: {
+        type: 'amd',
+        moduleName: 'namedModule',
+        files: {
+          'tmp/name.js': ['test/fixtures/name.js'],
+        }
     },
 
     // Unit tests.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,14 @@ module.exports = function(grunt) {
         files: {
           'tmp/name.js': ['test/fixtures/name.js'],
         }
+      },
+      anonymous: {
+        type: 'amd',
+        anonymous: true,
+        files: {
+          'tmp/anonymous.js': ['test/fixtures/anonymous.js'],
+        }
+      },
     },
 
     // Unit tests.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,12 @@ module.exports = function(grunt) {
           'tmp/anonymous.js': ['test/fixtures/anonymous.js'],
         }
       },
+      coffeeSrc: {
+        type: 'amd',
+        files: {
+          'tmp/coffee.coffee': ['test/fixtures/coffee.coffee'],
+        }
+      },
     },
 
     // Unit tests.

--- a/tasks/es6_module_transpiler.js
+++ b/tasks/es6_module_transpiler.js
@@ -16,8 +16,13 @@ module.exports = function(grunt) {
     var Compiler = require("es6-module-transpiler").Compiler,
         compiler, compiled, ext, method, moduleName;
 
+    if (options.moduleName) {
+      moduleName = options.moduleName;
+    }
+    else {
       ext = path.extname(src);
       moduleName = path.join(path.dirname(src), path.basename(src, ext));
+    }
 
     compiler = new Compiler(grunt.file.read(src), moduleName, options);
 
@@ -46,6 +51,7 @@ module.exports = function(grunt) {
 
     opts.imports = this.data.imports;
     opts.type = this.data.type;
+    opts.moduleName = this.data.moduleName;
 
     this.files.forEach(function(file){
       file.src.filter(function(path){

--- a/tasks/es6_module_transpiler.js
+++ b/tasks/es6_module_transpiler.js
@@ -10,11 +10,16 @@
 
 module.exports = function(grunt) {
 
+  var path = require('path');
+
   function transpile(src, dest, options){
     var Compiler = require("es6-module-transpiler").Compiler,
-        method, compiler, compiled;
+        compiler, compiled, ext, method, moduleName;
 
-    compiler = new Compiler(grunt.file.read(src), null, options);
+      ext = path.extname(src);
+      moduleName = path.join(path.dirname(src), path.basename(src, ext));
+
+    compiler = new Compiler(grunt.file.read(src), moduleName, options);
 
     switch(options.type){
     case 'cjs':

--- a/tasks/es6_module_transpiler.js
+++ b/tasks/es6_module_transpiler.js
@@ -16,6 +16,12 @@ module.exports = function(grunt) {
     var Compiler = require("es6-module-transpiler").Compiler,
         compiler, compiled, ext, method, moduleName;
 
+    ext = path.extname(src);
+
+    if (ext.slice(1) === 'coffee') {
+      options.coffee = true;
+    }
+
     if (options.moduleName) {
       moduleName = options.moduleName;
     }
@@ -23,7 +29,6 @@ module.exports = function(grunt) {
       moduleName = null;
     }
     else {
-      ext = path.extname(src);
       moduleName = path.join(path.dirname(src), path.basename(src, ext));
     }
 

--- a/tasks/es6_module_transpiler.js
+++ b/tasks/es6_module_transpiler.js
@@ -19,6 +19,9 @@ module.exports = function(grunt) {
     if (options.moduleName) {
       moduleName = options.moduleName;
     }
+    else if (options.anonymous) {
+      moduleName = null;
+    }
     else {
       ext = path.extname(src);
       moduleName = path.join(path.dirname(src), path.basename(src, ext));
@@ -52,6 +55,7 @@ module.exports = function(grunt) {
     opts.imports = this.data.imports;
     opts.type = this.data.type;
     opts.moduleName = this.data.moduleName;
+    opts.anonymous = this.data.anonymous;
 
     this.files.forEach(function(file){
       file.src.filter(function(path){

--- a/test/es6_module_transpiler_test.js
+++ b/test/es6_module_transpiler_test.js
@@ -71,4 +71,13 @@ exports.es6_module_transpiler = {
 
     test.done();
   },
+  coffeeSrc: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/coffee.coffee');
+    var expected = grunt.file.read('test/expected/coffee.coffee');
+    test.equal(actual, expected, 'understands coffee option');
+
+    test.done();
+  },
 };

--- a/test/es6_module_transpiler_test.js
+++ b/test/es6_module_transpiler_test.js
@@ -53,4 +53,13 @@ exports.es6_module_transpiler = {
 
     test.done();
   },
+  moduleNameOption: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/name.js')
+    var expected = grunt.file.read('test/expected/name.js')
+    test.equal(actual, expected, 'understands module option');
+
+    test.done();
+  },
 };

--- a/test/es6_module_transpiler_test.js
+++ b/test/es6_module_transpiler_test.js
@@ -62,4 +62,13 @@ exports.es6_module_transpiler = {
 
     test.done();
   },
+  anonymousOption: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/anonymous.js');
+    var expected = grunt.file.read('test/expected/anonymous.js');
+    test.equal(actual, expected, 'understands anonymous option');
+
+    test.done();
+  },
 };

--- a/test/expected/amd.js
+++ b/test/expected/amd.js
@@ -1,4 +1,4 @@
-define(
+define("test/fixtures/input",
   ["bar"],
   function(__dependency1__) {
     "use strict";

--- a/test/expected/anonymous.js
+++ b/test/expected/anonymous.js
@@ -1,0 +1,9 @@
+define(
+  ["exports"],
+  function(__exports__) {
+    "use strict";
+    var foo = "bar";
+
+
+    __exports__.foo = foo;
+  });

--- a/test/expected/coffee.coffee
+++ b/test/expected/coffee.coffee
@@ -1,0 +1,7 @@
+define("test/fixtures/coffee",
+  ["bar"],
+  (__dependency1__) ->
+    "use strict"
+    foo = __dependency1__.foo
+
+  )

--- a/test/expected/name.js
+++ b/test/expected/name.js
@@ -1,0 +1,9 @@
+define("namedModule",
+  ["exports"],
+  function(__exports__) {
+    "use strict";
+    var foo = "bar";
+
+
+    __exports__.foo = foo;
+  });

--- a/test/fixtures/anonymous.js
+++ b/test/fixtures/anonymous.js
@@ -1,0 +1,3 @@
+var foo = "bar";
+
+export { foo };

--- a/test/fixtures/coffee.coffee
+++ b/test/fixtures/coffee.coffee
@@ -1,0 +1,1 @@
+import foo from "bar"

--- a/test/fixtures/name.js
+++ b/test/fixtures/name.js
@@ -1,0 +1,3 @@
+var foo = "bar";
+
+export { foo };


### PR DESCRIPTION
Hi @joefiorini,

I needed coffee support so I added that. And I added support for the anonymous and module name options.

Also, I noted that the original behavior for naming was to make modules anonymous so I changed it to be identical to es6-module-transpiler.
