### PR TITLE
Add support for moduleName option to be a callback

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,29 @@ module.exports = function(grunt) {
           'tmp/name.js': ['test/fixtures/name.js'],
         }
       },
+      moduleNameCallback: {
+        type: 'amd',
+        moduleName: function(srcWithoutExt, file){
+          return 'my_app/' + srcWithoutExt.replace(/^test\/fixtures\//, '');
+        },
+        files: {
+          'tmp/name_callback.js': ['test/fixtures/name_callback.js'],
+        }
+      },
+      moduleNameCallbackWithCwd: {
+        type: 'amd',
+        moduleName: function(srcWithoutExt, file){
+          return 'my_app/' + srcWithoutExt;
+        },
+        files: [
+          {
+            expand: true,     // Enable dynamic expansion.
+            cwd: 'test/fixtures/lib/',      // Src matches are relative to this path.
+            src: ['**/*.js'], // Actual pattern(s) to match.
+            dest: 'tmp/'   // Destination path prefix.
+          }
+        ]
+      },
       anonymous: {
         type: 'amd',
         anonymous: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-es6-module-transpiler",
   "description": "A Grunt task for processing ES6 module import/export syntax into one of AMD, CommonJS or globals using the es6-module-transpiler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/joefiorini/grunt-es6-module-transpiler",
   "author": {
     "name": "Joe Fiorini",

--- a/test/es6_module_transpiler_test.js
+++ b/test/es6_module_transpiler_test.js
@@ -58,7 +58,25 @@ exports.es6_module_transpiler = {
 
     var actual = grunt.file.read('tmp/name.js');
     var expected = grunt.file.read('test/expected/name.js');
-    test.equal(actual, expected, 'understands module option');
+    test.equal(actual, expected, 'understands moduleName option');
+
+    test.done();
+  },
+  moduleNameCallbackOption: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/name_callback.js');
+    var expected = grunt.file.read('test/expected/name_callback.js');
+    test.equal(actual, expected, 'understands moduleName option with function');
+
+    test.done();
+  },
+  moduleNameCallbackOptionWithCwd: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/name_callback_with_cwd.js');
+    var expected = grunt.file.read('test/expected/name_callback_with_cwd.js');
+    test.equal(actual, expected, 'understands moduleName option with function with cwd');
 
     test.done();
   },

--- a/test/expected/name_callback.js
+++ b/test/expected/name_callback.js
@@ -1,0 +1,9 @@
+define("my_app/name_callback",
+  ["exports"],
+  function(__exports__) {
+    "use strict";
+    var foo = "bar";
+
+
+    __exports__.foo = foo;
+  });

--- a/test/expected/name_callback_with_cwd.js
+++ b/test/expected/name_callback_with_cwd.js
@@ -1,0 +1,9 @@
+define("my_app/name_callback_with_cwd",
+  ["exports"],
+  function(__exports__) {
+    "use strict";
+    var foo = "bar";
+
+
+    __exports__.foo = foo;
+  });

--- a/test/fixtures/lib/name_callback_with_cwd.js
+++ b/test/fixtures/lib/name_callback_with_cwd.js
@@ -1,0 +1,3 @@
+var foo = "bar";
+
+export { foo };

--- a/test/fixtures/name_callback.js
+++ b/test/fixtures/name_callback.js
@@ -1,0 +1,3 @@
+var foo = "bar";
+
+export { foo };


### PR DESCRIPTION
This PR adds support for the moduleName option to be a callback.

The callback is provided the default module name and should
return the desired module name. This is particularly useful
for adding or stripping module prefixes.

This commit also improves the default module naming by
stripping the cwd if it was specified in the files option.

@lukemelia/@kselden
