### PR TITLE
feat(windows compatibility): correct paths in Windows

### DIFF
--- a/tasks/es6_module_transpiler.js
+++ b/tasks/es6_module_transpiler.js
@@ -28,11 +28,13 @@ module.exports = function(grunt) {
     } else if (typeof options.moduleName === 'string') {
       moduleName = options.moduleName;
     } else {
-      moduleName = path.join(path.dirname(src), path.basename(src, ext));
-      if (file.orig.cwd)
+      moduleName = path.join(path.dirname(src), path.basename(src, ext)).replace(/[\\]/g, '/');
+      if (file.orig.cwd) {
         moduleName = moduleName.slice(file.orig.cwd.length);
-      if (options.moduleName)
+      }
+      if (options.moduleName) {
         moduleName = options.moduleName(moduleName, file);
+      }
     }
 
     compiler = new Compiler(grunt.file.read(src), moduleName, options);

--- a/test/es6_module_transpiler_test.js
+++ b/test/es6_module_transpiler_test.js
@@ -22,6 +22,10 @@ var grunt = require('grunt');
     test.ifError(value)
 */
 
+function normalizedFileRead(path) {
+  return grunt.util.normalizelf(grunt.file.read(path));
+}
+
 exports.es6_module_transpiler = {
   setUp: function(done) {
     done();
@@ -29,8 +33,8 @@ exports.es6_module_transpiler = {
   toCJS: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/cjs.js');
-    var expected = grunt.file.read('test/expected/cjs.js');
+    var actual = normalizedFileRead('tmp/cjs.js');
+    var expected = normalizedFileRead('test/expected/cjs.js');
     test.equal(actual, expected, 'outputs CommonJS');
 
     test.done();
@@ -38,8 +42,8 @@ exports.es6_module_transpiler = {
   toAMD: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/amd.js');
-    var expected = grunt.file.read('test/expected/amd.js');
+    var actual = normalizedFileRead('tmp/amd.js');
+    var expected = normalizedFileRead('test/expected/amd.js');
     test.equal(actual, expected, 'outputs AMD');
 
     test.done();
@@ -47,8 +51,8 @@ exports.es6_module_transpiler = {
   toGlobals: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/globals.js');
-    var expected = grunt.file.read('test/expected/globals.js');
+    var actual = normalizedFileRead('tmp/globals.js');
+    var expected = normalizedFileRead('test/expected/globals.js');
     test.equal(actual, expected, 'outputs Globals');
 
     test.done();
@@ -56,8 +60,8 @@ exports.es6_module_transpiler = {
   moduleNameOption: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/name.js');
-    var expected = grunt.file.read('test/expected/name.js');
+    var actual = normalizedFileRead('tmp/name.js');
+    var expected = normalizedFileRead('test/expected/name.js');
     test.equal(actual, expected, 'understands moduleName option');
 
     test.done();
@@ -65,8 +69,8 @@ exports.es6_module_transpiler = {
   moduleNameCallbackOption: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/name_callback.js');
-    var expected = grunt.file.read('test/expected/name_callback.js');
+    var actual = normalizedFileRead('tmp/name_callback.js');
+    var expected = normalizedFileRead('test/expected/name_callback.js');
     test.equal(actual, expected, 'understands moduleName option with function');
 
     test.done();
@@ -74,8 +78,8 @@ exports.es6_module_transpiler = {
   moduleNameCallbackOptionWithCwd: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/name_callback_with_cwd.js');
-    var expected = grunt.file.read('test/expected/name_callback_with_cwd.js');
+    var actual = normalizedFileRead('tmp/name_callback_with_cwd.js');
+    var expected = normalizedFileRead('test/expected/name_callback_with_cwd.js');
     test.equal(actual, expected, 'understands moduleName option with function with cwd');
 
     test.done();
@@ -83,8 +87,8 @@ exports.es6_module_transpiler = {
   anonymousOption: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/anonymous.js');
-    var expected = grunt.file.read('test/expected/anonymous.js');
+    var actual = normalizedFileRead('tmp/anonymous.js');
+    var expected = normalizedFileRead('test/expected/anonymous.js');
     test.equal(actual, expected, 'understands anonymous option');
 
     test.done();
@@ -92,8 +96,8 @@ exports.es6_module_transpiler = {
   coffeeSrc: function(test) {
     test.expect(1);
 
-    var actual = grunt.file.read('tmp/coffee.coffee');
-    var expected = grunt.file.read('test/expected/coffee.coffee');
+    var actual = normalizedFileRead('tmp/coffee.coffee');
+    var expected = normalizedFileRead('test/expected/coffee.coffee');
     test.equal(actual, expected, 'understands coffee option');
 
     test.done();


### PR DESCRIPTION
Please note: I've got a PR in to square/es6-module-transpiler: https://github.com/square/es6-module-transpiler/pull/16 with similar changes for running under Windows.  Together with that PR, I'm able to build and run the tests for grunt-es6-module-transpiler.

A couple of changes:
- replace backslashes from native format paths before using them in AMD require/define situations
- normalize linefeeds and file paths in tests
