### PR TITLE
Fix mixed CoffeeScript and JavaScript configs.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,6 +95,14 @@ module.exports = function(grunt) {
           'tmp/coffee.coffee': ['test/fixtures/coffee.coffee'],
         }
       },
+      mixedCoffeeAndJS: {
+        type: 'amd',
+        anonymous: true,
+        files: {
+          'tmp/anonymous.coffee': ['test/fixtures/anonymous.coffee'],
+          'tmp/anonymous.js': ['test/fixtures/anonymous.js'],
+        }
+      },
       enable: {
       }
     },

--- a/tasks/es6_module_transpiler.js
+++ b/tasks/es6_module_transpiler.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
 
   var path = require('path');
 
-  function transpile(file, options){
+  function transpile(file, options) {
     var src = file.src,
         Compiler = require("es6-module-transpiler").Compiler,
         compiler, compiled, ext, method, moduleName;
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
     ext = path.extname(src);
 
     if (ext.slice(1) === 'coffee') {
-      options.coffee = true;
+      options = grunt.util._.extend({coffee: true}, options);
     }
 
     if (options.anonymous) {

--- a/test/es6_module_transpiler_test.js
+++ b/test/es6_module_transpiler_test.js
@@ -102,6 +102,16 @@ exports.es6_module_transpiler = {
 
     test.done();
   },
+  mixedCoffeeAndJS: function(test) {
+    test.expect(1);
+
+    // in the config there is a .coffee file listed before this one
+    var actual = normalizedFileRead('tmp/anonymous.js');
+    var expected = normalizedFileRead('test/expected/anonymous.js');
+    test.equal(actual, expected, 'uses coffee option only on CoffeeScript files');
+
+    test.done();
+  },
   enable: function(test){
     test.expect(1);
 

--- a/test/expected/anonymous.coffee
+++ b/test/expected/anonymous.coffee
@@ -1,0 +1,9 @@
+define(
+  ["exports"]
+  (__exports__) ->
+    "use strict"
+    foo = "bar"
+
+
+    __exports__.foo = foo
+  )

--- a/test/fixtures/anonymous.coffee
+++ b/test/fixtures/anonymous.coffee
@@ -1,0 +1,3 @@
+foo = "bar"
+
+export { foo }


### PR DESCRIPTION
If you happened to have a configuration that mixed CS and JS and had a JS file transpiled after a CS file then the JS file would be transpiled as if it were CS. This is because the options hash was being modified by the transpile task.
