### PR TITLE
fixes `anonymous: true` option

### DIFF
--- a/tasks/es6_module_transpiler.js
+++ b/tasks/es6_module_transpiler.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
     }
 
     if (options.anonymous) {
-      moduleName = null;
+      moduleName = '';
     } else if (typeof options.moduleName === 'string') {
       moduleName = options.moduleName;
     } else {


### PR DESCRIPTION
newer versions of node won't take `undefined` or
`null` in path.join();.

when `moduleName` was null the amd compiler would
trip up on it, so we set it to empty string
