### PR TITLE
Update to latest es6-module-transpiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "es6-module-transpiler": "~0.3"
+    "es6-module-transpiler": "~0.4"
   }
 }


### PR DESCRIPTION
The module transpiler was recently updated to avoid adding trailing whitespace (in 0.4.0).

@joefiorini - Could you publish an updated version after merging?
